### PR TITLE
Railway Deployment Fixes: Environment-Agnostic Configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ ARG TARGET_ENVIRONMENT
 WORKDIR /app
 COPY --from=publish /app/publish .
 
-# appsettings files are already included in the publish output
-# No need to copy them separately as dotnet publish includes them
+# Copy appsettings files explicitly as they might not be included by dotnet publish in some environments
+COPY --from=build /src/WebAPI/appsettings*.json .
 
 
 # Create uploads directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,6 @@ RUN dotnet restore "WebAPI/WebAPI.csproj"
 # Copy all source code
 COPY . .
 
-# Debug: List files to see what's copied
-RUN ls -la /src/WebAPI/appsettings*
 
 # Build
 WORKDIR "/src/WebAPI"
@@ -42,11 +40,8 @@ ARG TARGET_ENVIRONMENT
 WORKDIR /app
 COPY --from=publish /app/publish .
 
-# Copy all appsettings files
-COPY --from=build /src/WebAPI/appsettings.json .
-COPY --from=build /src/WebAPI/appsettings.Development.json .
-COPY --from=build /src/WebAPI/appsettings.Staging.json .
-COPY --from=build /src/WebAPI/appsettings.Production.json .
+# appsettings files are already included in the publish output
+# No need to copy them separately as dotnet publish includes them
 
 
 # Create uploads directory


### PR DESCRIPTION
## Summary
Comprehensive fixes for Railway staging deployment issues and environment-agnostic refactoring.

## Primary Issues Fixed
✅ **Database Connection**: PostgreSQL connecting to localhost instead of Railway database
✅ **Redis SSL**: Certificate validation failures with Railway Redis
✅ **Docker Build**: Missing appsettings.json in multi-environment deployment
✅ **Configuration Precedence**: Environment variables not overriding appsettings.json

## Key Changes

### 1. Configuration System Fix (WebAPI/Program.cs)
- Fixed .NET Core configuration source ordering
- JSON files load first, environment variables override last
- Added cloud-agnostic environment variable configuration

### 2. Docker Multi-Environment Support (Dockerfile)
- Single Dockerfile supports Development/Staging/Production
- Build arguments: TARGET_ENVIRONMENT, BUILD_CONFIGURATION
- Environment-specific appsettings file renaming
- Proper file copying with conditional logic

### 3. Redis SSL Configuration (RedisCacheManager.cs)
- Disabled SSL for Railway Redis compatibility
- Maintained SSL support for other providers
- Configurable via CacheOptions__Ssl environment variable

### 4. Environment Variables (.env.railway.staging)
- Added CacheOptions__Ssl="false" for Railway Redis
- Maintained all existing Railway configuration
- Ready for production environment setup

## Build Arguments
```bash
# Staging build
docker build --build-arg TARGET_ENVIRONMENT=Staging .

# Production build  
docker build --build-arg TARGET_ENVIRONMENT=Production .
```

## Testing Verified
- ✅ Staging: appsettings.Staging.json → appsettings.json
- ✅ PostgreSQL: Railway database connection working
- ✅ Redis: Non-SSL connection working
- ✅ Docker: Multi-environment build successful

## Documentation
- Complete Railway deployment guide in claudedocs/
- Environment setup instructions
- Troubleshooting guide for common issues

🚀 Ready for staging deployment and production migration.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>