### PR TITLE
Add Railway environment files to gitignore (Staging → Development)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -474,3 +474,7 @@ UiPreparation/.DS_Store
 .env.production
 *.env
 !.env.*.template
+
+# Railway environment configuration files
+.env.railway.*
+!.env.railway.*.template


### PR DESCRIPTION
## Summary
- Added .env.railway.* pattern to .gitignore to prevent Railway environment configurations from being tracked
- Keeps template files trackable with !.env.railway.*.template pattern

## Changes
- Updated `.gitignore` to exclude all Railway environment files
- Railway configs are now properly ignored while templates remain trackable

## Test Plan
- [ ] Verify Railway environment files are not tracked in git
- [ ] Confirm template files can still be tracked if needed
- [ ] Ensure existing deployments continue to work

🤖 Generated with [Claude Code](https://claude.ai/code)