### PR TITLE
fix: Configuration-driven FileStorage Provider Selection

### DIFF
--- a/Business/DependencyResolvers/AutofacBusinessModule.cs
+++ b/Business/DependencyResolvers/AutofacBusinessModule.cs
@@ -198,36 +198,27 @@ namespace Business.DependencyResolvers
             builder.RegisterType<FreeImageHostStorageService>().InstancePerLifetimeScope();
             // builder.RegisterType<S3FileStorageService>().InstancePerLifetimeScope(); // Requires AWS SDK
             
-            // File Storage Services - Simple environment-based registration
-            // Read configuration at registration time to avoid DI issues
-            if (_configuration != null)
+            // File Storage Services - Configuration-driven registration
+            // Read FileStorage:Provider from configuration (supports environment variables)
+            builder.Register<IFileStorageService>(c =>
             {
-                var configManager = _configuration;
-                
-                // For now, register based on environment mode
-                // In Development/Staging: Use FreeImageHost, in Production: Use S3 or Local
-                switch (configManager.Mode)
+                var context = c.Resolve<IComponentContext>();
+                var config = context.Resolve<IConfiguration>();
+
+                // Read provider from configuration (supports environment variables like FileStorage__Provider)
+                var provider = config["FileStorage:Provider"] ?? "Local";
+
+                Console.WriteLine($"[FileStorage DI] Selected provider: {provider}");
+
+                return provider switch
                 {
-                    case ApplicationMode.Development:
-                    case ApplicationMode.Staging:
-                        // Development/Staging: Use FreeImageHost for external URL generation
-                        builder.Register<IFileStorageService>(c => c.Resolve<FreeImageHostStorageService>()).InstancePerLifetimeScope();
-                        break;
-                    case ApplicationMode.Production:
-                        // Production: Use Local file storage
-                        builder.Register<IFileStorageService>(c => c.Resolve<LocalFileStorageService>()).InstancePerLifetimeScope();
-                        break;
-                    default:
-                        // Default: Use Local file storage
-                        builder.Register<IFileStorageService>(c => c.Resolve<LocalFileStorageService>()).InstancePerLifetimeScope();
-                        break;
-                }
-            }
-            else
-            {
-                // No ConfigurationManager available, use LocalFileStorageService as fallback
-                builder.Register<IFileStorageService>(c => c.Resolve<LocalFileStorageService>()).InstancePerLifetimeScope();
-            }
+                    "FreeImageHost" => context.Resolve<FreeImageHostStorageService>(),
+                    "ImgBB" => context.Resolve<ImgBBStorageService>(),
+                    "Local" => context.Resolve<LocalFileStorageService>(),
+                    // "S3" => context.Resolve<S3FileStorageService>(), // Uncomment when S3 is implemented
+                    _ => context.Resolve<LocalFileStorageService>() // Default fallback
+                };
+            }).InstancePerLifetimeScope();
 
             switch (_configuration.Mode)
             {


### PR DESCRIPTION
## Summary
Replaces hardcoded `ApplicationMode.Production → LocalFileStorageService` with flexible configuration-driven provider selection in AutofacBusinessModule.

## Problem
- Production was **hardcoded** to use `LocalFileStorageService` (self-hosted)
- Staging used `FreeImageHostStorageService` (external HTTPS URLs)
- Railway environment variables (`FileStorage__Provider`) were **completely ignored**
- Result: Production images returned 404 errors, Flutter app couldn't load images

## Solution
**AutofacBusinessModule.cs (Lines 201-221)**: Replaced ApplicationMode switch with configuration-based DI:

```csharp
// OLD: Hardcoded based on ApplicationMode
case ApplicationMode.Production:
    builder.Register<IFileStorageService>(c => c.Resolve<LocalFileStorageService>());

// NEW: Configuration-driven
var provider = config["FileStorage:Provider"] ?? "Local";
return provider switch
{
    "FreeImageHost" => context.Resolve<FreeImageHostStorageService>(),
    "ImgBB" => context.Resolve<ImgBBStorageService>(),
    "Local" => context.Resolve<LocalFileStorageService>(),
    _ => context.Resolve<LocalFileStorageService>()
};
```

## Benefits
✅ **Environment Variable Support**: Railway `FileStorage__Provider="FreeImageHost"` now works  
✅ **Flexible Configuration**: Easy to switch between Local, FreeImageHost, ImgBB, S3  
✅ **No Code Changes**: Just change environment variables to switch storage providers  
✅ **Debugging**: Added `[FileStorage DI] Selected provider: {provider}` console log  
✅ **Production Parity**: Production can now use same external hosting as Staging

## Testing
- ✅ Build successful (no errors)
- ✅ Staging branch tested and verified
- ✅ Ready for production deployment

## Deployment Notes
After merge to master, ensure Railway environment variables are set:
```bash
FileStorage__Provider="FreeImageHost"
FileStorage__FreeImageHost__ApiKey="your-api-key"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)