### PR TITLE
fix: Add missing FarmerInvitationRequest queue to Worker Service config

### DIFF
--- a/PlantAnalysisWorkerService/appsettings.Production.json
+++ b/PlantAnalysisWorkerService/appsettings.Production.json
@@ -7,7 +7,8 @@
       "PlantAnalysisRequest": "plant-analysis-requests",
       "PlantAnalysisResult": "plant-analysis-results",
       "Notification": "notifications",
-      "DealerInvitationRequest": "dealer-invitation-requests"
+      "DealerInvitationRequest": "dealer-invitation-requests",
+      "FarmerInvitationRequest": "farmer-invitation-requests"
     },
     "RetrySettings": {
       "MaxRetryAttempts": 3,


### PR DESCRIPTION
## Problem
Worker Service was not processing farmer invitation messages because the RabbitMQ queue configuration was missing in Production appsettings.

## Root Cause
`PlantAnalysisWorkerService/appsettings.Production.json` had DealerInvitationRequest queue but was missing FarmerInvitationRequest queue configuration.

## Solution
✅ Added `"FarmerInvitationRequest": "farmer-invitation-requests"` to Worker RabbitMQ queues

## Impact
Worker Service can now listen to and process farmer invitation messages from the queue in Production environment.

## Git History Analysis
- **Jan 5, 2026** (Commit 2da6b4e7): Feature added to Dev/Staging only
- **Jan 6, 2026** (Commit 5623c467): WebAPI Production config updated, Worker Service missed
- **Jan 7, 2026** (Today): Fixed Worker Service Production config

## Testing
- ✅ Development/Staging: Already working (queue config existed since feature inception)
- ✅ Production: Will work after deployment with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)